### PR TITLE
Consolidate release configuration

### DIFF
--- a/.github/workflows/on_push_to_master.yaml
+++ b/.github/workflows/on_push_to_master.yaml
@@ -14,6 +14,8 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     runs-on: ubuntu-24.04
+    env:
+      GITHUB_PACKAGES_MAVEN_URL: https://maven.pkg.github.com/${{ github.repository }}
 
     permissions:
       contents: read
@@ -31,6 +33,20 @@ jobs:
           java-version: 21.0.10+7.0.LTS
 
       - uses: sbt/setup-sbt@508b753e53cb6095967669e0911487d2b9bc9f41 # v1.1.22
+
+      - name: Create sbt credentials file
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p "$HOME/.sbt/1.0"
+          cat > "$HOME/.sbt/1.0/ghpackages.credentials" <<EOF
+          realm=GitHub Package Registry
+          host=maven.pkg.github.com
+          user=${{ github.repository_owner }}
+          password=$GITHUB_TOKEN
+          EOF
+          chmod 600 "$HOME/.sbt/1.0/ghpackages.credentials"
 
       - name: Determine package metadata and SNAPSHOT
         id: pkg_meta

--- a/.github/workflows/on_release_tag.yaml
+++ b/.github/workflows/on_release_tag.yaml
@@ -8,6 +8,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-24.04
+    env:
+      GITHUB_PACKAGES_MAVEN_URL: https://maven.pkg.github.com/${{ github.repository }}
 
     permissions:
       contents: write
@@ -26,6 +28,20 @@ jobs:
           java-version: 21.0.10+7.0.LTS
 
       - uses: sbt/setup-sbt@508b753e53cb6095967669e0911487d2b9bc9f41 # v1.1.22
+
+      - name: Create sbt credentials file
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p "$HOME/.sbt/1.0"
+          cat > "$HOME/.sbt/1.0/ghpackages.credentials" <<EOF
+          realm=GitHub Package Registry
+          host=maven.pkg.github.com
+          user=${{ github.repository_owner }}
+          password=$GITHUB_TOKEN
+          EOF
+          chmod 600 "$HOME/.sbt/1.0/ghpackages.credentials"
 
       - name: Validate tag version with build.sbt
         id: release_meta

--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# types
+
+## Publish credentials setup
+
+This repository publishes Maven packages to GitHub Packages.
+
+Create a credentials file at `$HOME/.sbt/1.0/ghpackages.credentials` before running `sbt publish`.
+
+Example content:
+
+```ini
+realm=GitHub Package Registry
+host=maven.pkg.github.com
+user=<GitHub user name>
+password=<GitHub token with packages:write>
+```
+
+Notes:
+
+- Keep this file out of version control.
+- Publish is intended for GitHub Actions only.
+- In CI, generate the same file before publish.
+- The release-tag workflow publishes the package to GitHub Packages and also creates a GitHub Release.
+- Set `GITHUB_PACKAGES_MAVEN_URL` in CI, for example:
+  - `GITHUB_PACKAGES_MAVEN_URL=https://maven.pkg.github.com/<owner>/<repo>`

--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,11 @@
 ThisBuild / organization := "jp.kazzna"
 ThisBuild / scalaVersion := "3.8.3"
 ThisBuild / versionScheme := Some("early-semver")
-ThisBuild / publishTo := Some("GitHub Package Registry" at "https://maven.pkg.github.com/kazzna/types")
-ThisBuild / credentials ++= (sys.env.get("GITHUB_TOKEN") match {
-  case Some(token) => Seq(Credentials("GitHub Package Registry", "maven.pkg.github.com", "kazzna", token))
-  case None => Seq()
-})
+ThisBuild / publishTo := sys.env.get("GITHUB_PACKAGES_MAVEN_URL").map { url => 
+  "GitHub Package Registry" at url
+}
+ThisBuild / publish / skip := sys.env.get("GITHUB_ACTIONS") != Some("true")
+ThisBuild / credentials += Credentials(Path.userHome / ".sbt" / "1.0" / "ghpackages.credentials")
 
 lazy val root = (project in file("."))
   .settings(


### PR DESCRIPTION
This replaces the hardcoded Maven URL and inline token credential with a file-based credentials approach and an environment variable for the publish URL, keeping sensitive values out of build.sbt. A publish skip guard is also added to prevent accidental publishes outside CI. The README documents the required local setup for maintainers.